### PR TITLE
Landscaper: Remove deprecated can-util methods and replace with can-globals

### DIFF
--- a/can-ejs.js
+++ b/can-ejs.js
@@ -8,7 +8,7 @@ var namespace = require("can-namespace");
 var each = require("can-util/js/each/each");
 var canReflect = require("can-reflect");
 var observationReader = require("can-stache-key");
-var DOCUMENT = require('can-util/dom/document/document');
+var DOCUMENT = require('can-globals/document/document');
 
 var templateId = 0;
 // ## Helper methods

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "can-ejs",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -875,6 +875,16 @@
       "requires": {
         "can-dom-events": "1.0.3",
         "can-util": "3.9.10"
+      }
+    },
+    "can-globals": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/can-globals/-/can-globals-0.2.3.tgz",
+      "integrity": "sha512-U6ilaebEpBcgQETdRnj4LRynlK08on0dfWqrePFSW4T7nQpEL8WtzB4HFj9nJ5BXpf+xpblQqrn5WDTI604ohQ==",
+      "requires": {
+        "can-namespace": "1.0.0",
+        "can-reflect": "1.2.6",
+        "can-symbol": "1.0.0"
       }
     },
     "can-legacy-view-helpers": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "can-compute": "^3.3.0",
+    "can-globals": "^0.2.3",
     "can-legacy-view-helpers": "^0.6.0",
     "can-namespace": "^1.0.0",
     "can-observation": "^3.3.0",


### PR DESCRIPTION
This pull request was created with [Landscaper](https://github.com/bitovi/landscaper).
The following code mods were used to create this PR:

1. **https://gist.github.com/imaustink/d1faff15b89df8fb7964c5d5c3945e72**

Please review this PR carefully as Landscaper does not guarantee any code mod's quality.