### PR TITLE
initial update for can5 compatibility. all tests passing.

### DIFF
--- a/can-ejs.js
+++ b/can-ejs.js
@@ -3,10 +3,10 @@
 // `can.EJS`: Embedded JavaScript Templates
 //
 var legacyHelpers = require('can-legacy-view-helpers');
-var extend = require("can-util/js/assign/assign");
-var namespace = require("can-namespace");
-var each = require("can-util/js/each/each");
 var canReflect = require("can-reflect");
+var extend = canReflect.assign;
+var namespace = require("can-namespace");
+var each = canReflect.each;
 var observationReader = require("can-stache-key");
 var DOCUMENT = require('can-globals/document/document');
 var view = legacyHelpers.view;

--- a/package.json
+++ b/package.json
@@ -48,23 +48,26 @@
     ]
   },
   "dependencies": {
-    "can-compute": "^3.3.0",
-    "can-globals": "<2.0.0",
-    "can-legacy-view-helpers": "^1.0.0",
+    "can-compute": "^4.1.1",
+    "can-dom-data": "^1.0.2",
+    "can-dom-events": "^1.3.11",
+    "can-dom-mutate": "^1.3.9",
+    "can-globals": "^1.2.2",
+    "can-legacy-view-helpers": "canjs/can-legacy-view-helpers#can-5-compat",
     "can-namespace": "^1.0.0",
-    "can-observation": "^3.3.0",
-    "can-reflect": "^1.1.0",
-    "can-stache-key": "^0.1.0",
-    "can-util": "^3.9.0"
+    "can-observation": "^4.1.3",
+    "can-reflect": "^1.17.11",
+    "can-stache-key": "^1.4.3"
   },
   "devDependencies": {
-    "can-list": "^3.1.0",
-    "can-map": "^3.1.0",
-    "detect-cyclic-packages": "^1.1.0",
-    "jshint": "^2.9.1",
-    "steal": "^1.5.13",
+    "can-list": "^4.2.2",
+    "can-map": "^4.3.8",
+    "can-symbol": "^1.6.5",
+    "detect-cyclic-packages": "^1.1.1",
+    "jshint": "^2.10.2",
+    "steal": "^1.12.6",
     "steal-qunit": "^1.0.1",
-    "steal-tools": "^1.8.4",
+    "steal-tools": "^1.11.10",
     "testee": "^0.9.0"
   }
 }


### PR DESCRIPTION
Remove all usages of `can-util` in favor of `can-reflect` and other modern CanJS replacements.
Replace usages of removed `.each` method.

After merging this a new major release will be made.